### PR TITLE
feat: add coin_decimals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> Please note that this repository is still under development and needs testing and auditing. It is not production ready yet! 
+> Please note that this repository is still under development and needs testing and auditing. It is not production ready yet!
 
 <div align="center">  <img  width="446.5px" height="146.5px"  src="./assets/logo.png" /></div>
 
@@ -31,6 +31,7 @@ capabilities
 collections
 ├─ ac_collection — "Capability access wrapper for collections"
 ├─ bitmap — "Bitmap implementation for sequential keys"
+├─ coin_decimals — "A collection that stores Coin decimals"
 ├─ list — "A scalable vector implementation using dynamic fields"
 ├─ wit_collection - "Witness access wrapper for collections"
 defi

--- a/contracts/sources/collections/coin_decimals.move
+++ b/contracts/sources/collections/coin_decimals.move
@@ -6,20 +6,24 @@ module suitears::coin_decimals {
   use sui::dynamic_field as df;
   use sui::object::{Self, UID};
   use sui::tx_context::TxContext;
-  use sui::transfer::share_object;
   use sui::coin::{Self, CoinMetadata};
 
-  struct Decimals has store {
+  struct Decimals has store, copy, drop {
     decimals: u8,
     decimals_scalar: u64
   }
 
-  struct CoinDecimals has key {
+  struct CoinDecimals has key, store {
     id: UID
   }
 
-  fun init(ctx: &mut TxContext) {
-    share_object(CoinDecimals { id: object::new(ctx) });
+  public fun new(ctx: &mut TxContext): CoinDecimals {
+    CoinDecimals { id: object::new(ctx) }
+  }
+
+  public fun destroy(metada: CoinDecimals) {
+    let CoinDecimals { id } = metada;
+    object::delete(id);
   }
 
   public fun register_coin<CoinType>(metadata: &mut CoinDecimals, coin_metadata: &CoinMetadata<CoinType>) {

--- a/contracts/sources/collections/coin_decimals.move
+++ b/contracts/sources/collections/coin_decimals.move
@@ -1,0 +1,43 @@
+// Global Repo for protocols to know a coin decimals
+module suitears::metadata {
+  use std::type_name::{get, TypeName};
+
+  use sui::math::pow;
+  use sui::dynamic_field as df;
+  use sui::object::{Self, UID};
+  use sui::tx_context::TxContext;
+  use sui::transfer::share_object;
+  use sui::coin::{Self, CoinMetadata};
+
+  struct Decimals has store {
+    decimals: u8,
+    decimals_scalar: u64
+  }
+
+  struct CoinDecimals has key {
+    id: UID
+  }
+
+  fun init(ctx: &mut TxContext) {
+    share_object(CoinDecimals { id: object::new(ctx) });
+  }
+
+  public fun register_coin<CoinType>(metadata: &mut CoinDecimals, coin_metadata: &CoinMetadata<CoinType>) {
+    let decimals = coin::get_decimals(coin_metadata);
+    df::add(&mut metadata.id, get<CoinType>(), Decimals { decimals, decimals_scalar: pow(10, decimals) });
+  }
+
+  public fun get_decimals_scalar<CoinType>(metadata: &CoinDecimals): u64 {
+    let data = df::borrow<TypeName, Decimals>(&metadata.id, get<CoinType>());
+    data.decimals_scalar
+  }
+
+  public fun get_decimals<CoinType>(metadata: &CoinDecimals): u8 {
+    let data = df::borrow<TypeName, Decimals>(&metadata.id, get<CoinType>());
+    data.decimals
+  }
+
+  public fun is_coin_registered<CoinType>(metadata: &CoinDecimals): bool {
+    df::exists_(&metadata.id, get<CoinType>())
+  }
+}

--- a/contracts/sources/collections/coin_decimals.move
+++ b/contracts/sources/collections/coin_decimals.move
@@ -6,24 +6,20 @@ module suitears::coin_decimals {
   use sui::dynamic_field as df;
   use sui::object::{Self, UID};
   use sui::tx_context::TxContext;
+  use sui::transfer::share_object;
   use sui::coin::{Self, CoinMetadata};
 
-  struct Decimals has store, copy, drop {
+  struct Decimals has store {
     decimals: u8,
     decimals_scalar: u64
   }
 
-  struct CoinDecimals has key, store {
+  struct CoinDecimals has key {
     id: UID
   }
 
-  public fun new(ctx: &mut TxContext): CoinDecimals {
-    CoinDecimals { id: object::new(ctx) }
-  }
-
-  public fun destroy(metada: CoinDecimals) {
-    let CoinDecimals { id } = metada;
-    object::delete(id);
+  fun init(ctx: &mut TxContext) {
+    share_object(CoinDecimals { id: object::new(ctx) })
   }
 
   public fun register_coin<CoinType>(metadata: &mut CoinDecimals, coin_metadata: &CoinMetadata<CoinType>) {

--- a/contracts/sources/collections/coin_decimals.move
+++ b/contracts/sources/collections/coin_decimals.move
@@ -22,23 +22,23 @@ module suitears::coin_decimals {
     share_object(CoinDecimals { id: object::new(ctx) });
   }
 
-  public fun register_coin<CoinType>(metadata: &mut CoinDecimals, coin_metadata: &CoinMetadata<CoinType>) {
-    if (is_coin_registered<CoinType>(metadata)) return;
+  public fun register_coin<CoinType>(self: &mut CoinDecimals, coin_metadata: &CoinMetadata<CoinType>) {
+    if (is_coin_registered<CoinType>(self)) return;
     let decimals = coin::get_decimals(coin_metadata);
-    df::add(&mut metadata.id, get<CoinType>(), Decimals { decimals, decimals_scalar: pow(10, decimals) });
+    df::add(&mut self.id, get<CoinType>(), Decimals { decimals, decimals_scalar: pow(10, decimals) });
   }
 
-  public fun get_decimals_scalar<CoinType>(metadata: &CoinDecimals): u64 {
-    let data = df::borrow<TypeName, Decimals>(&metadata.id, get<CoinType>());
+  public fun get_decimals_scalar<CoinType>(self: &CoinDecimals): u64 {
+    let data = df::borrow<TypeName, Decimals>(&self.id, get<CoinType>());
     data.decimals_scalar
   }
 
-  public fun get_decimals<CoinType>(metadata: &CoinDecimals): u8 {
-    let data = df::borrow<TypeName, Decimals>(&metadata.id, get<CoinType>());
+  public fun get_decimals<CoinType>(self: &CoinDecimals): u8 {
+    let data = df::borrow<TypeName, Decimals>(&self.id, get<CoinType>());
     data.decimals
   }
 
-  public fun is_coin_registered<CoinType>(metadata: &CoinDecimals): bool {
-    df::exists_(&metadata.id, get<CoinType>())
+  public fun is_coin_registered<CoinType>(self: &CoinDecimals): bool {
+    df::exists_(&self.id, get<CoinType>())
   }
 }

--- a/contracts/sources/collections/coin_decimals.move
+++ b/contracts/sources/collections/coin_decimals.move
@@ -19,7 +19,7 @@ module suitears::coin_decimals {
   }
 
   fun init(ctx: &mut TxContext) {
-    share_object(CoinDecimals { id: object::new(ctx) })
+    share_object(CoinDecimals { id: object::new(ctx) });
   }
 
   public fun register_coin<CoinType>(metadata: &mut CoinDecimals, coin_metadata: &CoinMetadata<CoinType>) {

--- a/contracts/sources/collections/coin_decimals.move
+++ b/contracts/sources/collections/coin_decimals.move
@@ -1,5 +1,5 @@
 // Global Repo for protocols to know a coin decimals
-module suitears::metadata {
+module suitears::coin_decimals {
   use std::type_name::{get, TypeName};
 
   use sui::math::pow;

--- a/contracts/sources/collections/coin_decimals.move
+++ b/contracts/sources/collections/coin_decimals.move
@@ -23,6 +23,7 @@ module suitears::coin_decimals {
   }
 
   public fun register_coin<CoinType>(metadata: &mut CoinDecimals, coin_metadata: &CoinMetadata<CoinType>) {
+    if (is_coin_registered<CoinType>(metadata)) return;
     let decimals = coin::get_decimals(coin_metadata);
     df::add(&mut metadata.id, get<CoinType>(), Decimals { decimals, decimals_scalar: pow(10, decimals) });
   }


### PR DESCRIPTION
A collection to store all coin metadatas.

Once we deploy on mainnet, DeFi protocols can integrate it easily.