### PR TITLE
feat: add to_string lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ sft
 utils
 ├─ comparator — "Module to compare u8 vectors (bits)"
 ├─ merkle_proof — "Module to verify Merkle proofs"
+├─ to_string — "Module to convert u128 to ascii strings"
 ├─ upgrade — "Module to add a timelock to contract upgrades"
 ├─ vectors — "Utility functions for vectors"
 ├─ whitelist — "A plugin to add whitelist functionalities to any object"

--- a/contracts/sources/utils/to_string.move
+++ b/contracts/sources/utils/to_string.move
@@ -6,6 +6,7 @@ module suitears::to_string {
 
     const HEX_SYMBOLS: vector<u8> = b"0123456789abcdef";
 
+    #[test_only]
     const MAX_U128: u128 = 340282366920938463463374607431768211455;
 
     /// @dev Converts a `u128` to its `ascii::String` decimal representation.

--- a/contracts/sources/utils/to_string.move
+++ b/contracts/sources/utils/to_string.move
@@ -1,0 +1,110 @@
+// Credit https://github.com/pentagonxyz/movemate/blob/main/sui/sources/to_string.move
+
+module suitears::to_string {
+    use std::ascii::{Self, String};
+    use std::vector;
+
+    const HEX_SYMBOLS: vector<u8> = b"0123456789abcdef";
+
+    const MAX_U128: u128 = 340282366920938463463374607431768211455;
+
+    /// @dev Converts a `u128` to its `ascii::String` decimal representation.
+    public fun to_string(value: u128): String {
+        if (value == 0) {
+            return ascii::string(b"0")
+        };
+        let buffer = vector::empty<u8>();
+        while (value != 0) {
+            vector::push_back(&mut buffer, ((48 + value % 10) as u8));
+            value = value / 10;
+        };
+        vector::reverse(&mut buffer);
+        ascii::string(buffer)
+    }
+
+    /// @dev Converts a `u128` to its `ascii::String` hexadecimal representation.
+    public fun to_hex_string(value: u128): String {
+        if (value == 0) {
+            return ascii::string(b"0x00")
+        };
+        let temp: u128 = value;
+        let length: u128 = 0;
+        while (temp != 0) {
+            length = length + 1;
+            temp = temp >> 8;
+        };
+        to_hex_string_fixed_length(value, length)
+    }
+
+    /// @dev Converts a `u128` to its `ascii::String` hexadecimal representation with fixed length (in whole bytes).
+    /// so the returned String is `2 * length + 2`(with '0x') in size
+    public fun to_hex_string_fixed_length(value: u128, length: u128): String {
+        let buffer = vector::empty<u8>();
+
+        let i: u128 = 0;
+        while (i < length * 2) {
+            vector::push_back(&mut buffer, *vector::borrow(&mut HEX_SYMBOLS, (value & 0xf as u64)));
+            value = value >> 4;
+            i = i + 1;
+        };
+        assert!(value == 0, 1);
+        vector::append(&mut buffer, b"x0");
+        vector::reverse(&mut buffer);
+        ascii::string(buffer)
+    }
+
+    /// @dev Converts a `vector<u8>` to its `ascii::String` hexadecimal representation.
+    /// so the returned String is `2 * length + 2`(with '0x') in size
+    public fun bytes_to_hex_string(bytes: &vector<u8>): String {
+        let length = vector::length(bytes);
+        let buffer = b"0x";
+
+        let i: u64 = 0;
+        while (i < length) {
+            let byte = *vector::borrow(bytes, i);
+            vector::push_back(&mut buffer, *vector::borrow(&mut HEX_SYMBOLS, (byte >> 4 & 0xf as u64)));
+            vector::push_back(&mut buffer, *vector::borrow(&mut HEX_SYMBOLS, (byte & 0xf as u64)));
+            i = i + 1;
+        };
+        ascii::string(buffer)
+    }
+
+    #[test]
+    fun test_to_string() {
+        assert!(b"0" == ascii::into_bytes(to_string(0)), 1);
+        assert!(b"1" == ascii::into_bytes(to_string(1)), 1);
+        assert!(b"257" == ascii::into_bytes(to_string(257)), 1);
+        assert!(b"10" == ascii::into_bytes(to_string(10)), 1);
+        assert!(b"12345678" == ascii::into_bytes(to_string(12345678)), 1);
+        assert!(b"340282366920938463463374607431768211455" == ascii::into_bytes(to_string(MAX_U128)), 1);
+    }
+
+    #[test]
+    fun test_to_hex_string() {
+        assert!(b"0x00" == ascii::into_bytes(to_hex_string(0)), 1);
+        assert!(b"0x01" == ascii::into_bytes(to_hex_string(1)), 1);
+        assert!(b"0x0101" == ascii::into_bytes(to_hex_string(257)), 1);
+        assert!(b"0xbc614e" == ascii::into_bytes(to_hex_string(12345678)), 1);
+        assert!(b"0xffffffffffffffffffffffffffffffff" == ascii::into_bytes(to_hex_string(MAX_U128)), 1);
+    }
+
+    #[test]
+    fun test_to_hex_string_fixed_length() {
+        assert!(b"0x00" == ascii::into_bytes(to_hex_string_fixed_length(0, 1)), 1);
+        assert!(b"0x01" == ascii::into_bytes(to_hex_string_fixed_length(1, 1)), 1);
+        assert!(b"0x10" == ascii::into_bytes(to_hex_string_fixed_length(16, 1)), 1);
+        assert!(b"0x0011" == ascii::into_bytes(to_hex_string_fixed_length(17, 2)), 1);
+        assert!(b"0x0000bc614e" == ascii::into_bytes(to_hex_string_fixed_length(12345678, 5)), 1);
+        assert!(b"0xffffffffffffffffffffffffffffffff" == ascii::into_bytes(to_hex_string_fixed_length(MAX_U128, 16)), 1);
+    }
+
+    #[test]
+    fun test_bytes_to_hex_string() {
+        assert!(b"0x00" == ascii::into_bytes(bytes_to_hex_string(&x"00")), 1);
+        assert!(b"0x01" == ascii::into_bytes(bytes_to_hex_string(&x"01")), 1);
+        assert!(b"0x1924bacf" == ascii::into_bytes(bytes_to_hex_string(&x"1924bacf")), 1);
+        assert!(b"0x8324445443539749823794832789472398748932794327743277489327498732" == ascii::into_bytes(bytes_to_hex_string(&x"8324445443539749823794832789472398748932794327743277489327498732")), 1);
+        assert!(b"0xbfee823235227564" == ascii::into_bytes(bytes_to_hex_string(&x"bfee823235227564")), 1);
+        assert!(b"0xffffffffffffffffffffffffffffffff" == ascii::into_bytes(bytes_to_hex_string(&x"ffffffffffffffffffffffffffffffff")), 1);
+    }
+}


### PR DESCRIPTION
Allows a user to convert u64 to strings.

This is tested and should not increase the audit cost. Hopefully :)