### PR TITLE
fix: dao flash loan fee

### DIFF
--- a/contracts/sources/governance/dao_treasury.move
+++ b/contracts/sources/governance/dao_treasury.move
@@ -300,6 +300,10 @@ module suitears::dao_treasury {
     )
   }
 
+  public fun view_flash_loan<DaoWitness: drop, CoinType>(flash_loan: &FlashLoan<DaoWitness, CoinType>): (TypeName, u64) {
+    (flash_loan.type, flash_loan.fee)
+  }
+
   public fun repay_flash_loan<DaoWitness: drop, CoinType>(
     treasury: &mut DaoTreasury<DaoWitness>, 
     flash_loan: FlashLoan<DaoWitness, CoinType>,

--- a/contracts/sources/governance/dao_treasury.move
+++ b/contracts/sources/governance/dao_treasury.move
@@ -59,7 +59,8 @@ module suitears::dao_treasury {
     allow_flashloan: bool
   }
 
-  // * IMPORTANT do not add abilities
+  // * IMPORTANT do not add abilities 
+  // (see https://docs.sui.io/concepts/sui-move-concepts/patterns/hot-potato)
   struct FlashLoan<phantom DaoWitness, phantom CoinType> {
     initial_balance: u64,
     fee: u64,

--- a/contracts/sources/governance/dao_treasury.move
+++ b/contracts/sources/governance/dao_treasury.move
@@ -62,6 +62,7 @@ module suitears::dao_treasury {
   // * IMPORTANT do not add abilities
   struct FlashLoan<phantom DaoWitness, phantom CoinType> {
     initial_balance: u64,
+    fee: u64,
     type: TypeName
   }
 
@@ -295,7 +296,7 @@ module suitears::dao_treasury {
 
     (
       coin::take<CoinType>(bag::borrow_mut(&mut treasury.coins, type), value, ctx),
-      FlashLoan { initial_balance , type }
+      FlashLoan { initial_balance , type, fee: (roll_mul_up((value as u128), FLASH_LOAN_FEE) as u64) }
     )
   }
 
@@ -304,10 +305,10 @@ module suitears::dao_treasury {
     flash_loan: FlashLoan<DaoWitness, CoinType>,
     token: Coin<CoinType>
   ) {
-    let FlashLoan { initial_balance, type } = flash_loan;
+    let FlashLoan { initial_balance, type, fee } = flash_loan;
     balance::join(bag::borrow_mut(&mut treasury.coins, type), coin::into_balance(token));
 
-    let final_balance = initial_balance + (roll_mul_up((initial_balance as u128), FLASH_LOAN_FEE) as u64);
+    let final_balance = initial_balance + fee;
     assert!(final_balance >= balance::value(bag::borrow<TypeName, Balance<CoinType>>(&treasury.coins, type)), ERepayAmountTooLow);
   }
 }


### PR DESCRIPTION
The previous fee was based on the total balance and not the borrowed amount.