### PR TITLE
Review dao

### DIFF
--- a/contracts/sources/governance/dao.move
+++ b/contracts/sources/governance/dao.move
@@ -1,5 +1,6 @@
 // Based from https://github.com/starcoinorg/starcoin-framework/blob/main/sources/Dao.move
 // Before creating a DAO make sure your tokens are properly distributed
+// Do not add capabilities to hot potatoes (see https://docs.sui.io/concepts/sui-move-concepts/patterns/hot-potato)
 module suitears::dao {
   use std::vector;
   use std::option::{Self, Option};

--- a/contracts/sources/governance/dao.move
+++ b/contracts/sources/governance/dao.move
@@ -72,7 +72,7 @@ module suitears::dao {
     voting_period: u64,
     /// the quorum rate to agree on the proposal.
     /// if 50% votes needed, then the voting_quorum_rate should be 50.
-    /// it should between (0, 100 wad].
+    /// it should between (0, 100 * 1e9].
     voting_quorum_rate: u64,
     /// how long the proposal should wait before it can be executed (in milliseconds).
     min_action_delay: u64,
@@ -89,7 +89,7 @@ module suitears::dao {
     against_votes: u64,
     eta: u64, // executable after this time
     action_delay: u64, // after how long, the agreed proposal can be executed.
-    quorum_votes: u64, // how many votes to reach to make the proposal pass.
+    quorum_votes: u64, // the number of votes to pass the proposal.
     voting_quorum_rate: u64, 
     rules: Option<Rules<T>>,
     hash: vector<u8>

--- a/contracts/sources/governance/dao_action.move
+++ b/contracts/sources/governance/dao_action.move
@@ -1,6 +1,6 @@
 module suitears::dao_action {
   use std::vector;
-  use std::type_name::{get, TypeName};
+  use std::type_name::{Self, TypeName};
 
   use sui::vec_set::{Self, VecSet};
 
@@ -24,7 +24,7 @@ module suitears::dao_action {
   }
 
   public fun complete_rule<DaoWitness: drop, CoinType, T: store, Rule: drop>(_: Rule, action: &mut Action<DaoWitness, CoinType, T>) {
-    vec_set::insert(&mut action.completed, get<Rule>());
+    vec_set::insert(&mut action.completed, type_name::get<Rule>());
   }
 
   public fun finish_action<DaoWitness: drop, CoinType, T: store>(action: Action<DaoWitness, CoinType, T>): T {
@@ -36,8 +36,10 @@ module suitears::dao_action {
     let index = 0;
     
     while (rules_size > index) {
-      let rule = *vector::borrow(&rules, index);
-      assert!(vec_set::contains(&completed, &rule), EInvalidRules);
+      let rule = vector::borrow(&rules, index);
+      assert!(vec_set::contains(&completed, rule), EInvalidRules);
+
+      index = index + 1;
     };
 
     payload

--- a/contracts/sources/governance/dao_treasury.move
+++ b/contracts/sources/governance/dao_treasury.move
@@ -128,6 +128,7 @@ module suitears::dao_treasury {
 
   public fun donate<DaoWitness: drop, CoinType>(treasury: &mut DaoTreasury<DaoWitness>, token: Coin<CoinType>, ctx: &mut TxContext) {
     let key = get<CoinType>();
+    let value = coin::value(&token);
 
     if (!bag::contains(&treasury.coins, key)) {
       bag::add(&mut treasury.coins, key, coin::into_balance(token))
@@ -135,7 +136,7 @@ module suitears::dao_treasury {
       balance::join(bag::borrow_mut<TypeName, Balance<CoinType>>(&mut treasury.coins, key), coin::into_balance(token));
     };
 
-    emit(Donate<DaoWitness, CoinType> { value: coin::value(&token), donator: tx_context::sender(ctx) });
+    emit(Donate<DaoWitness, CoinType> { value, donator: tx_context::sender(ctx) });
   }
 
   public fun view_coin_balance<DaoWitness: drop, CoinType>(treasury: &DaoTreasury<DaoWitness>): u64 {

--- a/contracts/sources/governance/dao_treasury.move
+++ b/contracts/sources/governance/dao_treasury.move
@@ -60,7 +60,6 @@ module suitears::dao_treasury {
   }
 
   // * IMPORTANT do not add abilities 
-  // (see https://docs.sui.io/concepts/sui-move-concepts/patterns/hot-potato)
   struct FlashLoan<phantom DaoWitness, phantom CoinType> {
     initial_balance: u64,
     fee: u64,


### PR DESCRIPTION
check if those changes are ok for you (not sure what were your initial intentions):
- changed voting_quorum u128 -> u64 because u64 is large enough and I prefer consistency
-  modify Config constructor to use both Option and 0 (delay, period can be 0), Option can easily be constructed and passed from frontend (`bcs.option(bcs.u64()).serialize(amount)`)
- added queue function from starcoin example otherwise it wouldn't work if we don't remove the `eta` field