### PR TITLE
fix: owner cap api and usage

### DIFF
--- a/contracts/sources/capabilities/owner.move
+++ b/contracts/sources/capabilities/owner.move
@@ -31,13 +31,13 @@ module suitears::owner {
     assert!(owns(self, x), ENotAllowed);
   }
 
-  public fun remove<T: drop>(self: &mut OwnerCap<T>, x: ID) {
+  public fun remove<T: drop>(_: T, self: &mut OwnerCap<T>, x: ID) {
     let (present, i) = vector::index_of(&self.of, &x);
     if (!present) return;
     vector::remove(&mut self.of, i);
   }
 
-  public fun add<T: drop>(self: &mut OwnerCap<T>, x: ID) {
+  public fun add<T: drop>(_: T, self: &mut OwnerCap<T>, x: ID) {
     if (vector::contains(&self.of, &x)) return;
     vector::push_back(&mut self.of, x);
   }


### PR DESCRIPTION
The old OwnerCap API required the module that imports it to wrap around a new object.

The new API requires the Witness to mutate the permissions